### PR TITLE
v1.1.1: Rename #DBQuery and #DBSession methods

### DIFF
--- a/cassandra/connection.go
+++ b/cassandra/connection.go
@@ -12,12 +12,12 @@ type ClusterDriver interface {
 
 var session *driver.Session
 
-// GetSession creates new GoCQL connection if required,
+// GetSession creates new GoCql connection if required,
 // and returns the existing or newly creating session.
 // The returned Session is a Singleton.
 func GetSession(cluster ClusterDriver) (*driver.Session, error) {
 	var err error
-	if session == nil || session.DBSession().Closed() {
+	if session == nil || session.GoCqlSession().Closed() {
 		var s *cql.Session
 		s, err = cluster.CreateSession()
 		session = driver.NewSession(s)

--- a/cassandra/driver/iterx.go
+++ b/cassandra/driver/iterx.go
@@ -21,7 +21,7 @@ type Iterx struct {
 // NewIterx returns a new Iterx Instance
 func NewIterx(q QueryI) IterxI {
 	return &Iterx{
-		iterx: cqlx.Iter(q.DBQuery()),
+		iterx: cqlx.Iter(q.GoCqlQuery()),
 		query: q,
 	}
 }

--- a/cassandra/driver/query.go
+++ b/cassandra/driver/query.go
@@ -4,7 +4,7 @@ import cql "github.com/gocql/gocql"
 
 // QueryI is the query-handler for database-session.
 type QueryI interface {
-	DBQuery() *cql.Query
+	GoCqlQuery() *cql.Query
 	Exec() error
 	GetPageSize() uint
 	SetPageSize(n uint) QueryI
@@ -18,8 +18,8 @@ type Query struct {
 	query    *cql.Query
 }
 
-// DBQuery returns the embedded GoCQL query.
-func (q *Query) DBQuery() *cql.Query {
+// GoCqlQuery returns the embedded GoCql query.
+func (q *Query) GoCqlQuery() *cql.Query {
 	return q.query
 }
 

--- a/cassandra/driver/queryx.go
+++ b/cassandra/driver/queryx.go
@@ -30,7 +30,7 @@ func NewQueryx(q QueryI, names []string) QueryxI {
 
 // BindMap binds query named parameters using Map.
 func (q *Queryx) BindMap(arg map[string]interface{}) QueryxI {
-	cqx := cqlx.Query(q.query.DBQuery(), q.ColumnNames).
+	cqx := cqlx.Query(q.query.GoCqlQuery(), q.ColumnNames).
 		BindMap(arg).
 		Query
 	q.query = &Query{
@@ -42,7 +42,7 @@ func (q *Queryx) BindMap(arg map[string]interface{}) QueryxI {
 // BindStruct binds query named parameters to values from arg using mapper.
 // If value cannot be found an error is reported.
 func (q *Queryx) BindStruct(arg interface{}) QueryxI {
-	cqx := cqlx.Query(q.query.DBQuery(), q.ColumnNames).
+	cqx := cqlx.Query(q.query.GoCqlQuery(), q.ColumnNames).
 		BindStruct(arg).
 		Query
 	q.query = &Query{

--- a/cassandra/driver/session.go
+++ b/cassandra/driver/session.go
@@ -5,7 +5,7 @@ import cql "github.com/gocql/gocql"
 // SessionI is the database connection-session.
 type SessionI interface {
 	Query(stmt string, values ...interface{}) QueryI
-	DBSession() *cql.Session
+	GoCqlSession() *cql.Session
 }
 
 // Session is the database-session implementation.
@@ -32,8 +32,8 @@ func (s *Session) Close() {
 	s.session.Close()
 }
 
-// DBSession returns the original wrapped GoCQL-Session object.
-func (s *Session) DBSession() *cql.Session {
+// GoCqlSession returns the original wrapped GoCql-Session object.
+func (s *Session) GoCqlSession() *cql.Session {
 	return s.session
 }
 

--- a/mocks/query.go
+++ b/mocks/query.go
@@ -20,10 +20,10 @@ type Query struct {
 	WrappedQuery    *cql.Query
 }
 
-// DBQuery mocks the getter for wrapped GoCQL-Query.
+// GoCqlQuery mocks the getter for wrapped GoCql-Query.
 // The WrappedQuery member of Query must be explicitely set, else this will
 // return a gocql.Query with just statement set.
-func (q *Query) DBQuery() *cql.Query {
+func (q *Query) GoCqlQuery() *cql.Query {
 	if q.WrappedQuery != nil {
 		return q.WrappedQuery
 	}

--- a/mocks/session.go
+++ b/mocks/session.go
@@ -12,8 +12,8 @@ type Session struct {
 	MockQueryExecError string
 }
 
-// DBSession is a no-op
-func (s *Session) DBSession() *cql.Session {
+// GoCqlSession is a no-op
+func (s *Session) GoCqlSession() *cql.Session {
 	return nil
 }
 


### PR DESCRIPTION
This provides more idiomatic method-naming.

* #DBQuery renamed to #GoCqlQuery
* #DBSession renamed to #GoCqlSession