### PR TITLE
v1.1.2: Refactor #GetSession code

### DIFF
--- a/cassandra/connection.go
+++ b/cassandra/connection.go
@@ -16,15 +16,14 @@ var session *driver.Session
 // and returns the existing or newly creating session.
 // The returned Session is a Singleton.
 func GetSession(cluster ClusterDriver) (*driver.Session, error) {
-	var err error
 	if session == nil || session.GoCqlSession().Closed() {
 		var s *cql.Session
-		s, err = cluster.CreateSession()
+		s, err := cluster.CreateSession()
+		if err != nil {
+			return nil, err
+		}
 		session = driver.NewSession(s)
 	}
 
-	if err != nil {
-		return nil, err
-	}
 	return session, nil
 }


### PR DESCRIPTION
This prevents an edge case where if getting Cassandra session returns error, the CassandraUtils session will be wrapped around a nil GoCql session, and although at that moment the error is returned as intended, however, when trying to reuse or recreate the session, it causes nil-reference error since the CassandraUtils session is non-nil, but the embedded GoCql session is nil.